### PR TITLE
Fix cabal metadata

### DIFF
--- a/cardano-mainnet-mirror.cabal
+++ b/cardano-mainnet-mirror.cabal
@@ -12,10 +12,12 @@ category:            Currency
 extra-source-files:  README.md
 data-dir:            epochs
 data-files:          *.index *.epoch *.boundary
+build-type:          Simple
 
 library
   exposed-modules:     Cardano.Mirror
   other-modules:       Paths_cardano_mainnet_mirror
+  autogen-modules:     Paths_cardano_mainnet_mirror
   build-depends:       base
                      , directory
                      , filepath


### PR DESCRIPTION
Have to specify the build type, otherwise cabal ends up complaining that it is using a custom Setup.hs which needs Cabal <1.25 (because of the lack of specifying that field) but >2.0 because of the specification within the .cabal file itself.

Needed to build the `cardano-chain` with all testsuites enabled with cabal.